### PR TITLE
Add Streamlit web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ Run the advanced analyzer which draws a sentiment chart and can export results t
 ```bash
 python3 moodmapper_transformer.py mytext.txt --json result.json --image grafico.png
 ```
+
+### Web app (Streamlit)
+
+Install all optional dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the interactive web interface:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Enter your text (one line per snippet) and click **Analisar** to see the emotional analysis, color-coded chart and suggested soundtrack. You can also download the JSON results directly from the page.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+transformers
+torch
+matplotlib
+streamlit
+pandas

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,32 @@
+import json
+import pandas as pd
+import streamlit as st
+from moodmapper_transformer import analyze_text, overall_music
+
+st.title("MoodMapper Web")
+
+st.write("Digite seu texto (uma frase por linha):")
+text = st.text_area("Texto", height=200)
+
+if st.button("Analisar"):
+    if not text.strip():
+        st.warning("Digite algum texto para analisar.")
+    else:
+        with st.spinner("Analisando..."):
+            results = analyze_text(text)
+        st.subheader("Resultados")
+        for item in results:
+            st.write(f"{item['line']} -> {item['label']} ({item['score']:.2f})")
+        music = overall_music(results)
+        if music:
+            st.write("Trilha sugerida:", music)
+        # Prepare data for bar chart
+        df = pd.DataFrame({
+            'Trecho': [f"{i+1}" for i in range(len(results))],
+            'Score': [r['score'] for r in results],
+            'Cor': [r['color'] for r in results]
+        })
+        chart = pd.DataFrame({'Score': df['Score']}, index=df['Trecho'])
+        st.bar_chart(chart)
+        json_data = json.dumps(results, ensure_ascii=False, indent=2)
+        st.download_button('Baixar JSON', json_data, 'resultado.json', 'application/json')


### PR DESCRIPTION
## Summary
- create `streamlit_app.py` for interactive web usage
- add `requirements.txt`
- document how to run the Streamlit web app

## Testing
- `python3 -m py_compile moodmapper.py moodmapper_transformer.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68480c76836c832387aa140ba18df0fa