### PR TITLE
Add Portuguese support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Simple tool to map emotions in text.
 2. Run the analyzer:
 
 ```bash
-python3 moodmapper.py mytext.txt --json result.json
+python3 moodmapper.py mytext.txt --json result.json --lang pt
 ```
 
 The script will print the dominant emotion for each sentence, a short summary
-and suggestions for color and music. If `--json` is provided, the per-sentence
-analysis is saved to the given file in JSON format.
+and suggestions for color and music. Use `--lang pt` for Portuguese text (default
+is English). If `--json` is provided, the per-sentence analysis is saved to the
+given file in JSON format.
 
 ### With transformers
 

--- a/moodmapper.py
+++ b/moodmapper.py
@@ -12,6 +12,16 @@ EMOTION_WORDS: Dict[str, List[str]] = {
     "surprise": ["surprised", "shocked", "astonished", "amazed"],
 }
 
+# Portuguese synonyms for emotion detection
+EMOTION_WORDS_PT: Dict[str, List[str]] = {
+    "joy": ["feliz", "alegria", "contente", "animado", "esperanca", "riso"],
+    "sadness": ["triste", "desanimo", "lagrima", "chorar", "melancolia", "deprimido"],
+    "anger": ["raiva", "furioso", "irritado", "odio"],
+    "fear": ["medo", "assustado", "apavorado", "nervoso", "panico"],
+    "disgust": ["nojo", "repulsa", "enojado"],
+    "surprise": ["surpreso", "chocado", "espantado", "admirado"],
+}
+
 EMOTION_COLORS = {
     "joy": "yellow",
     "sadness": "blue",
@@ -33,14 +43,15 @@ EMOTION_MUSIC = {
 SENTENCE_RE = re.compile(r"[^.!?]+[.!?]?")
 
 
-def analyze_text(text: str):
+def analyze_text(text: str, lang: str = "en"):
     """Return list of dicts with sentence and dominant emotion."""
+    words_map = EMOTION_WORDS_PT if lang == "pt" else EMOTION_WORDS
     sentences = [s.strip() for s in SENTENCE_RE.findall(text) if s.strip()]
     results = []
     for sentence in sentences:
         word_counts = Counter(re.findall(r"\b\w+\b", sentence.lower()))
         scores = {}
-        for emotion, words in EMOTION_WORDS.items():
+        for emotion, words in words_map.items():
             scores[emotion] = sum(word_counts.get(w, 0) for w in words)
         dominant = max(scores, key=scores.get) if any(scores.values()) else None
         results.append({
@@ -72,12 +83,14 @@ def main():
     parser = argparse.ArgumentParser(description="Simple MoodMapper")
     parser.add_argument("input", help="path to text file")
     parser.add_argument("--json", dest="json_path", help="export analysis as JSON")
+    parser.add_argument("--lang", choices=["en", "pt"], default="en",
+                        help="language of the text (en or pt)")
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as f:
         text = f.read()
 
-    results = analyze_text(text)
+    results = analyze_text(text, args.lang)
     summary, color, music = summarize(results)
 
     for item in results:

--- a/tests/test_moodmapper.py
+++ b/tests/test_moodmapper.py
@@ -1,0 +1,7 @@
+import moodmapper
+
+def test_analyze_text_portuguese():
+    text = "Estou muito feliz. Que alegria!"
+    results = moodmapper.analyze_text(text, lang="pt")
+    emotions = [r["dominant_emotion"] for r in results]
+    assert emotions == ["joy", "joy"]


### PR DESCRIPTION
## Summary
- support Portuguese emotion words in `moodmapper.py`
- allow selecting language with `--lang`
- document the new option in the README
- add a simple test covering Portuguese analysis

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480f0cd9708323ad908e694561e421